### PR TITLE
Upgrade Go to v1.20.1

### DIFF
--- a/.github/workflows/pre-main.yml
+++ b/.github/workflows/pre-main.yml
@@ -13,10 +13,10 @@ jobs:
     runs-on: ubuntu-20.04
 
     steps:
-      - name: Set up Go 1.19
+      - name: Set up Go 1.20
         uses: actions/setup-go@v3
         with:
-          go-version: 1.19.6
+          go-version: 1.20.1
 
       - name: Disable default go problem matcher
         run: echo "::remove-matcher owner=go::"

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN yum install -y gcc git jq make wget
 
 # Install Go binary
 ENV GO_DL_URL="https://golang.org/dl"
-ENV GO_BIN_TAR="go1.19.6.linux-amd64.tar.gz"
+ENV GO_BIN_TAR="go1.20.1.linux-amd64.tar.gz"
 ENV GO_BIN_URL_x86_64=${GO_DL_URL}/${GO_BIN_TAR}
 ENV GOPATH="/root/go"
 RUN if [[ "$(uname -m)" -eq "x86_64" ]] ; then \

--- a/Dockerfile.local
+++ b/Dockerfile.local
@@ -9,7 +9,7 @@ RUN yum install -y gcc git jq make wget
 
 # Install Go binary
 ENV GO_DL_URL="https://golang.org/dl"
-ENV GO_BIN_TAR="go1.19.6.linux-amd64.tar.gz"
+ENV GO_BIN_TAR="go1.20.1.linux-amd64.tar.gz"
 ENV GO_BIN_URL_x86_64=${GO_DL_URL}/${GO_BIN_TAR}
 ENV GOPATH="/root/go"
 RUN if [[ "$(uname -m)" -eq "x86_64" ]] ; then \

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/test-network-function/oct
 
-go 1.19
+go 1.20
 
 require (
 	github.com/hashicorp/go-version v1.6.0


### PR DESCRIPTION
Release Notes: https://tip.golang.org/doc/go1.20

Related to: https://github.com/test-network-function/cnf-certification-test/pull/873