### PR TITLE
Add dependabot for container images

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,3 +6,7 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "daily"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/ubi:latest AS builder
+FROM registry.access.redhat.com/ubi8/ubi:8.7 AS builder
 ARG OCT_REPO=github.com/test-network-function/oct.git
 ARG TOKEN
 ENV OCT_FOLDER=/usr/oct

--- a/Dockerfile.local
+++ b/Dockerfile.local
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/ubi:latest AS builder
+FROM registry.access.redhat.com/ubi8/ubi:8.7 AS builder
 ARG OCT_LOCAL_FOLDER
 
 ENV OCT_FOLDER=/usr/oct


### PR DESCRIPTION
Related to: https://github.com/test-network-function/cnf-certification-test/pull/936

This doesn't include the Dockerfile linting from #936 rather just the dependabot setup and versioning changes.