### PR TITLE
Update golangci-lint to v1.52.1

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -120,6 +120,6 @@ issues:
 # golangci.com configuration
 # https://github.com/golangci/golangci/wiki/Configuration
 service:
-  golangci-lint-version: 1.51.x # use the fixed version to not introduce new linters unexpectedly
+  golangci-lint-version: 1.52.x # use the fixed version to not introduce new linters unexpectedly
   prepare:
     - echo "here I can run custom commands, but no preparation needed for this repo"

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ GO_PACKAGES=$(shell go list ./... | grep -v vendor)
 	vet
 
 OCT_TOOL_NAME=oct
-GOLANGCI_VERSION=v1.51.1
+GOLANGCI_VERSION=v1.52.1
 
 # Run the unit tests and build all binaries
 build:

--- a/cmd/tnf/fetch/fetch.go
+++ b/cmd/tnf/fetch/fetch.go
@@ -60,7 +60,7 @@ func NewCommand() *cobra.Command {
 }
 
 // RunCommand execute the fetch subcommands
-func RunCommand(cmd *cobra.Command, args []string) error {
+func RunCommand(cmd *cobra.Command, _ []string) error {
 	data := getCertifiedCatalogOnDisk()
 	log.Infof("Current offline artifacts: %+v", data)
 	b, err := cmd.PersistentFlags().GetBool(operatorFlag)


### PR DESCRIPTION
Related to: https://github.com/test-network-function/cnf-certification-test/pull/946