### PR TITLE
Adding support for hardcoded redhat registry (registry.redhat.io)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,7 +57,7 @@ coverage-html: test
 	go tool cover -html cover.out
 
 update-certified-catalog:
-	./tnf fetch --operator --container --helm
+	./oct fetch --operator --container --helm
 
 # Update source dependencies and fix versions
 update-deps:

--- a/certdb/offlinecheck/container.go
+++ b/certdb/offlinecheck/container.go
@@ -43,8 +43,7 @@ type ContainerCatalogEntry struct {
 	ID                string       `json:"_id"`
 	Architecture      string       `json:"architecture"`
 	Certified         bool         `json:"certified"`
-	DockerImageDigest string       `json:"docker_image_digest"`
-	DockerImageID     string       `json:"docker_image_id"` // image digest
+	DockerImageDigest string       `json:"image_id"`
 	Repositories      []Repository `json:"repositories"`
 }
 type ContainerPageCatalog struct {


### PR DESCRIPTION
This Pull request adds registry.redhat.io entries to the offline database. Only entries less than one year old are retrieved.