### PR TITLE
Update GolangCI-lint to v1.53.3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ GO_PACKAGES=$(shell go list ./... | grep -v vendor)
 	vet
 
 OCT_TOOL_NAME=oct
-GOLANGCI_VERSION=v1.53.2
+GOLANGCI_VERSION=v1.53.3
 
 # Run the unit tests and build all binaries
 build:


### PR DESCRIPTION
Related to: https://github.com/test-network-function/cnf-certification-test/pull/1236

https://github.com/golangci/golangci-lint/releases/tag/v1.53.3