### PR TITLE
Fix go directive to include patch version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/test-network-function/oct
 
-go 1.21
+go 1.21.1
 
 require (
 	github.com/hashicorp/go-version v1.6.0


### PR DESCRIPTION
Similar to: https://github.com/test-network-function/cnf-certification-test/pull/1392