### PR TITLE
adding digest map entry for manifest_list_digest to support multi-architecture images

### DIFF
--- a/certdb/offlinecheck/container.go
+++ b/certdb/offlinecheck/container.go
@@ -34,9 +34,10 @@ type Tag struct {
 	Name string `json:"name"`
 }
 type Repository struct {
-	Registry   string `json:"registry"`
-	Repository string `json:"repository"`
-	Tags       []Tag  `json:"tags"`
+	Registry              string `json:"registry"`
+	Repository            string `json:"repository"`
+	Tags                  []Tag  `json:"tags"`
+	DockerImageListDigest string `json:"manifest_list_digest"`
 }
 
 type ContainerCatalogEntry struct {
@@ -85,7 +86,12 @@ func LoadBinary(bytes []byte, db map[string]*ContainerCatalogEntry) (entries int
 	entries = len(aCatalog.Data)
 	for i := 0; i < entries; i++ {
 		c := aCatalog.Data[i]
+		// image digest based entry
 		db[c.DockerImageDigest] = &c
+		if len(c.Repositories) > 0 {
+			// image list digest based entry
+			db[c.Repositories[0].DockerImageListDigest] = &c
+		}
 	}
 
 	return entries, nil

--- a/cmd/tnf/fetch/fetch.go
+++ b/cmd/tnf/fetch/fetch.go
@@ -16,7 +16,7 @@ import (
 
 var (
 	// containersCatalogSizeURL = "https://catalog.redhat.com/api/containers/v1/images?filter=certified==true&page=0&include=total,page_size"
-	containersCatalogPageURL = "https://catalog.redhat.com/api/containers/v1/images?filter=certified==true&page_size=%d&page=%d&include=data.repositories,data.image_id,data.architecture"
+	containersCatalogPageURL = "https://catalog.redhat.com/api/containers/v1/images?filter=certified==true&page_size=%d&page=%d&include=data.repositories,data.image_id,data.architecture,repositories.manifest_list_digest"
 	operatorsCatalogSizeURL  = "https://catalog.redhat.com/api/containers/v1/operators/bundles?filter=organization==certified-operators"
 	operatorsCatalogPageURL  = "https://catalog.redhat.com/api/containers/v1/operators/bundles?filter=organization==certified-operators&page_size=%d&page=%d"
 	helmCatalogURL           = "https://charts.openshift.io/index.yaml"


### PR DESCRIPTION
images that support multiple architectures do not use image_id but use the manifest_list_digest field instead to have a consitent digest across architectures. we add a digest entry to the container database for the new multi architecture digest