### PR TITLE
Add multi-arch support for arm64/amd64 builds

### DIFF
--- a/.github/workflows/recreate-image.yml
+++ b/.github/workflows/recreate-image.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   recreate-oct-container-image:
     name: Create new OCT container image
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     env:
       SHELL: /bin/bash
 
@@ -21,8 +21,10 @@ jobs:
           ref: main
           token: ${{ secrets.PULL_TOKEN }}
 
-      - name: Build OCT container image
-        run:  docker build -t quay.io/testnetworkfunction/oct:latest --build-arg TOKEN=${{ secrets.PULL_TOKEN }} --no-cache .
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
 
       - name: Authenticate against Quay.io
         uses: docker/login-action@v3
@@ -33,5 +35,15 @@ jobs:
           username: ${{ secrets.QUAY_ROBOT_USER }}
           password: ${{ secrets.QUAY_ROBOT_TOKEN }}
 
-      - name: Push the newly built image to Quay.io
-        run: docker push quay.io/testnetworkfunction/oct:latest
+      - name: Build and push the latest images for multi-arch
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          build-args: |
+            TOKEN=${{ secrets.PULL_TOKEN }}
+          file: ./Dockerfile
+          platforms: linux/amd64,linux/arm64
+          no-cache: true
+          push: true
+          tags: |
+            quay.io/testnetworkfunction/oct:latest


### PR DESCRIPTION
Similar to:
- https://github.com/test-network-function/cnf-certification-test/pull/1953
- https://github.com/test-network-function/cnf-certification-test-partner/pull/417

Changes:
- Bumps the runner version to ubuntu-22.04
- Sets up QEMU and Docker Buildx.
- Uses the `docker-build-and-push` action to build the image for multi-arch and push to registry.