### PR TITLE
Fix manifest_list_digest; remove mongo ping

### DIFF
--- a/cmd/tnf/fetch/fetch.go
+++ b/cmd/tnf/fetch/fetch.go
@@ -16,7 +16,7 @@ import (
 
 var (
 	// containersCatalogSizeURL = "https://catalog.redhat.com/api/containers/v1/images?filter=certified==true&page=0&include=total,page_size"
-	containersCatalogPageURL = "https://catalog.redhat.com/api/containers/v1/images?filter=certified==true&page_size=%d&page=%d&include=data.repositories,data.image_id,data.architecture,repositories.manifest_list_digest"
+	containersCatalogPageURL = "https://catalog.redhat.com/api/containers/v1/images?filter=certified==true&page_size=%d&page=%d&include=data.repositories,data.image_id,data.architecture"
 	operatorsCatalogSizeURL  = "https://catalog.redhat.com/api/containers/v1/operators/bundles?filter=organization==certified-operators"
 	operatorsCatalogPageURL  = "https://catalog.redhat.com/api/containers/v1/operators/bundles?filter=organization==certified-operators&page_size=%d&page=%d"
 	helmCatalogURL           = "https://charts.openshift.io/index.yaml"

--- a/pkg/certdb/onlinecheck/onlinecheck.go
+++ b/pkg/certdb/onlinecheck/onlinecheck.go
@@ -43,7 +43,6 @@ const certifiedContainerCatalogDigestURL = "https://catalog.redhat.com/api/conta
 const certifiedContainerCatalogListDigestURL = "https://catalog.redhat.com/api/containers/v1/images?filter=repositories.manifest_list_digest==%s"
 const certifiedContainerCatalogTagURL = "https://catalog.redhat.com/api/containers/v1/repositories/registry/%s/repository/%s/tag/%s"
 const redhatCatalogPingURL = "https://catalog.redhat.com/api/containers/v1/ping"
-const redhatCatalogPingMongoDBURL = "https://catalog.redhat.com/api/containers/v1/status/mongo"
 
 var (
 	dataKey           = "data"
@@ -74,9 +73,6 @@ func NewOnlineValidator() OnlineValidator {
 // IsServiceReachable check if redhat catalog is reachable and its database is available to query
 func (validator OnlineValidator) IsServiceReachable() bool {
 	if _, err := validator.GetRequest(redhatCatalogPingURL); err != nil {
-		return false
-	}
-	if _, err := validator.GetRequest(redhatCatalogPingMongoDBURL); err != nil {
 		return false
 	}
 	return true


### PR DESCRIPTION
This gets the `oct` build back up and running.  We can add back in more verification in subsequent PRs.