### PR TITLE
Add sanity check for oct endpoints

### DIFF
--- a/.github/actions/slack-webhook-sender/action.yml
+++ b/.github/actions/slack-webhook-sender/action.yml
@@ -1,0 +1,34 @@
+name: slack-webhook-sender
+description: 'Sends a slack message plus some more workflow job related fields to a slack webhook endpoint.'
+inputs:
+  message:
+    description: 'Text that will be send in the json .message field.'
+    required: true
+    default: 'Hello, world!'
+  slack_webhook:
+    description: 'Slack webhook where the data will be posted.'
+    required: true
+    default: ''
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Post message data to slack's webhook url.
+      shell: bash
+      env:
+        MESSAGE: ${{ inputs.message }}
+        REPO_URL: 'https://github.com/${{ github.repository }}'
+        COMMIT_URL: 'https://github.com/${{ github.repository }}/commit/${{ github.sha }}'
+        JOB_URL: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}/attempts/${{ github.run_attempt }}'
+        ATTEMPT: ${{ github.run_attempt }}
+      run: |
+          data="{                              \
+            \"message\"   : \"${MESSAGE}\",    \
+            \"repo_url\"  : \"${REPO_URL}\",   \
+            \"job_url\"   : \"${JOB_URL}\",    \
+            \"commit_url\": \"${COMMIT_URL}\", \
+            \"attempt\"   : \"${ATTEMPT}\"     \
+          }"
+
+          echo "Sending alert message data to slack webhook: $(echo $data | jq)"
+          curl -X POST --data "${data}" -H 'Content-type: application/json; charset=UTF-8' '${{ inputs.slack_webhook }}'

--- a/.github/workflows/pre-main.yml
+++ b/.github/workflows/pre-main.yml
@@ -39,3 +39,7 @@ jobs:
 
       - name: make vet
         run: make vet
+
+      - name: Run endpoint verification script
+        run: |
+          ./scripts/curl-endpoints.sh

--- a/.github/workflows/recreate-image.yml
+++ b/.github/workflows/recreate-image.yml
@@ -35,6 +35,10 @@ jobs:
           username: ${{ secrets.QUAY_ROBOT_USER }}
           password: ${{ secrets.QUAY_ROBOT_TOKEN }}
 
+      - name: Run endpoint verification script
+        run: |
+          ./scripts/curl-endpoints.sh
+
       - name: Build and push the latest images for multi-arch
         uses: docker/build-push-action@v5
         with:
@@ -47,3 +51,11 @@ jobs:
           push: true
           tags: |
             quay.io/testnetworkfunction/oct:latest
+
+
+      - name: If failed to create the image, send alert msg to dev team.
+        if: ${{ failure() }}
+        uses: ./.github/actions/slack-webhook-sender
+        with:
+          message: 'Failed to create official latest OCT image. Please check the logs.'
+          slack_webhook: '${{ secrets.SLACK_ALERT_WEBHOOK_URL }}'

--- a/scripts/curl-endpoints.sh
+++ b/scripts/curl-endpoints.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+# This script is used to test the endpoints of the API
+# to make sure they are alive and healthy
+
+# Define the endpoints
+endpoints=(
+  "https://catalog.redhat.com/api/containers/v1/operators/bundles"
+  "https://catalog.redhat.com/api/containers/v1/images"
+  "https://catalog.redhat.com/api/containers/v1/ping"
+  "https://catalog.redhat.com/api/containers/v1/images?filter=certified==true&page_size=100&page=0&include=data.repositories,data.image_id,data.architecture,data.repositories.manifest_list_digest"
+  "https://charts.openshift.io/index.yaml"
+  "https://catalog.redhat.com/api/containers/v1/operators/bundles?filter=organization==certified-operators&page_size=100&page=0"
+  "https://catalog.redhat.com/api/containers/v1/operators/bundles?filter=organization==certified-operators"
+)
+
+# Loop through the endpoints and exit if any of them fail
+for endpoint in "${endpoints[@]}"
+do
+  printf "Testing endpoint: $endpoint\n"
+  curl -s -o /dev/null -w "%{http_code}" $endpoint
+  printf "\n"
+  if [ $? -ne 0 ]; then
+    echo "Failed to reach endpoint: $endpoint"
+    exit 1
+  fi
+done


### PR DESCRIPTION
Similar to: https://github.com/test-network-function/cnf-certification-test/pull/1929

- Adds a script to curl endpoints prior to image creation.
- Also runs the endpoint curl as part of PR checks.
- Sends a message to dev team if the image creation job fails.